### PR TITLE
Fix dynamic reconfigure parameters

### DIFF
--- a/cfg/CameraParameters.cfg
+++ b/cfg/CameraParameters.cfg
@@ -82,17 +82,17 @@ stereo.add('ShadowingThreshold', int_t, level=0, default=1, min=-1, max=2,
 
 ## Postproc parameters
 postproc = gen.add_group('Postproc')
-postproc.add('UniquenessRatio', int_t, level=0, default=0, min=0, max=99,
+postproc.add('UniquenessRatio', int_t, level=0, default=10, min=0, max=99,
              description="Filters the pixels depending on the uniqueness of the found correspondence. The value indicates the percentage, by which the cost of the next best correspondence must be larger (compared to the best correspondence), such that the pixel is accepted. Input para is an integer specifying the uniqueness margin in percent. Setting this parameter to 0 disables the uniqueness filter.")
-postproc.add('MedianFilterRadius', int_t, level=0, default=0, min=0, max=2 ,
+postproc.add('MedianFilterRadius', int_t, level=0, default=1, min=0, max=2 ,
              description="Specifies the size of the median filter as radius in pixels, excluding the center pixel.The filter is applied to the disparity map. Median filtering will reduce noise inside surfaces while maintaining sharp edges, but object corners will be rounded. Input para is an integer specifying half the median filter window size in pixels, excluding the center pixel. Setting the filter radius to 0 will disable median filtering.")
-postproc.add('SpeckleComponentThreshold', int_t, level=0, default=1, min=1, max=16 ,
+postproc.add('SpeckleComponentThreshold', int_t, level=0, default=3, min=1, max=16 ,
              description="Defines how the image is divided into regions for speckle filtering. Whenever two neighboring pixel disparities differ by more than ComponentThreshold disparities, the two pixels are considered as belonging to separate regions. Consequently, each resulting region will not have discontinuities larger or equal to ComponentThreshold in it's disparity map area. The smaller this threshold is set, the smaller the resulting disparity regions will be. Thus setting a smaller ComponentThreshold will result in more regions being filtered out, because some regions fall apart and their sizes drop below RegionSize.")
-postproc.add('SpeckleRegionSize', int_t, level=0, default=0, min=0, max=1000 ,
+postproc.add('SpeckleRegionSize', int_t, level=0, default=150, min=0, max=1000 ,
              description="The size in pixels of a disparity map region below which the region will be removed from the disparity map. The computation of the regions is controlled by ComponentThreshold. Input para is an integer specifying the size in pixels below which a region will be removed from the disparity map. Setting this parameter to 0 disables the speckle filter.")
-postproc.add('FillBorderSpread', int_t, level=0, default=1, min=1, max=16 ,
+postproc.add('FillBorderSpread', int_t, level=0, default=3, min=1, max=16 ,
              description="Defines which missing regions will be filled by setting a threshold on the maximum spread of the disparities on the region boundary. Setting this value reasonably small will ensure that only missing patches inside planar faces will be filled whereas gaps at depth discontinuities are kept unfilled. Input para is an integer specifying the maximum spread of the disparities at the fill region border.")
-postproc.add('FillRegionSize', int_t, level=0, default=0, min=0, max=300 ,
+postproc.add('FillRegionSize', int_t, level=0, default=150, min=0, max=300 ,
              description="Defines an upper limit on the region size in pixels, up to which a region is accepted for filling. The region must also satisfy the BorderSpread condition to be filled. Input para is an integer specifying region size in pixels, up to which a missing region is being filled. Setting this parameter to 0 disables the hole filling filter.")
 
 exit(gen.generate(PACKAGE, 'ensenso_driver', 'CameraParameters'))

--- a/cfg/CameraParameters.cfg
+++ b/cfg/CameraParameters.cfg
@@ -22,7 +22,7 @@ capture.add('AutoGain',         bool_t,   level=0, default=True,
           description="When set to true the Gain will be adjusted after each Capture command involving this camera.")
 capture.add('Binning',          int_t,    level=0, default=1,     min=1,    max=2,
           description="A positive integer specifying the binning factor.")
-capture.add('BlackLevelOffset', double_t, level=0, default=1.0,   min=0.0,  max=1.0,
+capture.add('BlackLevelOffset', double_t, level=0, default=0.55,   min=0.0,  max=1.0,
           description="A number between 0.0 and 1.0. Values closer to zero will yield darker images, values closer to one will increase the image brightness at the expense of noise in dark image regions.")
 capture.add('DisparityMapAOI',  bool_t,   level=0, default=False, 
           description="When set to true the camera's capture AOI will be reduced.")

--- a/launch/viewer.launch
+++ b/launch/viewer.launch
@@ -28,17 +28,17 @@
     <param name="FlexView"          type="bool"   value="false" />
     <param name="FlexViewImages"    type="int"    value="2" />
     <param name="FrontLight"        type="bool"   value="false" />
-    <param name="Gain"              type="int"    value="1" />
-    <param name="GainBoost"         type="bool"   value="true" />
+    <param name="Gain"              type="double" value="1.0" />
+    <param name="GainBoost"         type="bool"   value="false" />
     <param name="HardwareGamma"     type="bool"   value="true" />
-    <param name="Hdr"               type="bool"   value="true" />
+    <param name="Hdr"               type="bool"   value="false" />
     <param name="PixelClock"        type="int"    value="24" />
     <param name="Projector"         type="bool"   value="true" />
     <param name="TargetBrightness"  type="int"    value="80" />
     <param name="TriggerMode"       type="int"    value="0" />      <!-- Software: 0, FallingEdge: 1, RisingEdge: 2 -->
     <!-- Stereo parameters -->
-    <param name="MinimumDisparity"      type="int"    value="-117" />
-    <param name="NumberOfDisparities"   type="int"    value="64" />
+    <param name="MinimumDisparity"      type="int"    value="-64" />
+    <param name="NumberOfDisparities"   type="int"    value="128" />
     <param name="OptimizationProfile"   type="int"    value="2" />  <!-- Aligned: 0, Diagonal: 1, AlignedAndDiagonal: 2 -->
     <param name="Scaling"               type="double" value="1.0" />
     <param name="DepthChangeCost"       type="int"    value="5" />

--- a/launch/viewer.launch
+++ b/launch/viewer.launch
@@ -10,13 +10,10 @@
   
   <!-- Ensenso driver -->
   <node name="ensenso_driver" pkg="ensenso" type="ensenso_driver" ns="camera" output="screen"> 
+    <!-- Static parameters -->
     <param name="stream_calib_pattern"  type="bool"   value="False" />
     <param name="serial"                type="string" value="$(arg serial)" />
     <param name="camera_frame_id"       type="string" value="camera_optical_frame" />
-  </node>
-  
-  <!-- Driver configuration -->
-  <node name="driver_dynconfig" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters ensenso_driver" ns="camera">
     <!-- Capture parameters -->
     <param name="AutoBlackLevel"    type="bool"   value="true" />
     <param name="AutoExposure"      type="bool"   value="true" />

--- a/launch/viewer.launch
+++ b/launch/viewer.launch
@@ -41,6 +41,16 @@
     <param name="NumberOfDisparities"   type="int"    value="64" />
     <param name="OptimizationProfile"   type="int"    value="2" />  <!-- Aligned: 0, Diagonal: 1, AlignedAndDiagonal: 2 -->
     <param name="Scaling"               type="double" value="1.0" />
+    <param name="DepthChangeCost"       type="int"    value="5" />
+    <param name="DepthStepCost"         type="int"    value="30" />
+    <param name="ShadowingThreshold"    type="int"    value="1" />
+    <!-- Postprocessing parameters -->
+    <param name="UniquenessRatio"           type="int" value="10" />
+    <param name="MedianFilterRadius"        type="int" value="1" />
+    <param name="SpeckleComponentThreshold" type="int" value="3" />
+    <param name="SpeckleRegionSize"         type="int" value="150" />
+    <param name="FillBorderSpread"          type="int" value="3" />
+    <param name="FillRegionSize"            type="int" value="150" />
     <!-- Streaming parameters -->    
     <param name="Cloud"   type="bool"   value="true" />
     <param name="Images"  type="bool"   value="true" />

--- a/launch/viewer.launch
+++ b/launch/viewer.launch
@@ -22,7 +22,7 @@
     <param name="AutoExposure"      type="bool"   value="true" />
     <param name="AutoGain"          type="bool"   value="true" />
     <param name="Binning"           type="int"    value="1" />
-    <param name="BlackLevelOffset"  type="double" value="1.0" />
+    <param name="BlackLevelOffset"  type="double" value="0.55" />
     <param name="DisparityMapAOI"   type="bool"   value="false" />
     <param name="Exposure"          type="double" value="1.5" />
     <param name="FlexView"          type="bool"   value="false" />

--- a/src/ensenso_driver.cpp
+++ b/src/ensenso_driver.cpp
@@ -158,7 +158,7 @@ class EnsensoDriver
     {
       // Process enumerators
       std::string trigger_mode, profile;
-      switch (config.groups.capture.TriggerMode)
+      switch (config.TriggerMode)
       {
         case 0:
           trigger_mode = "Software";
@@ -172,7 +172,7 @@ class EnsensoDriver
         default:
           trigger_mode = "Software";
       }
-      switch (config.groups.stereo.OptimizationProfile)
+      switch (config.OptimizationProfile)
       {
         case 0:
           profile = "Aligned";
@@ -188,83 +188,83 @@ class EnsensoDriver
       }
       ROS_DEBUG("---");
       ROS_DEBUG("Capture Parameters");
-      ROS_DEBUG_STREAM("AutoBlackLevel: "   << std::boolalpha << config.groups.capture.AutoBlackLevel);
-      ROS_DEBUG_STREAM("AutoExposure: "     << std::boolalpha << config.groups.capture.AutoExposure);
-      ROS_DEBUG_STREAM("AutoGain: "         << std::boolalpha << config.groups.capture.AutoGain);
-      ROS_DEBUG_STREAM("Binning: "          << config.groups.capture.Binning);
-      ROS_DEBUG_STREAM("BlackLevelOffset: " << config.groups.capture.BlackLevelOffset);
-      ROS_DEBUG_STREAM("Exposure: "         << config.groups.capture.Exposure);
-      ROS_DEBUG_STREAM("FlexView: "         << std::boolalpha << config.groups.capture.FlexView);
-      ROS_DEBUG_STREAM("FlexViewImages: "   << config.groups.capture.FlexViewImages);
-      ROS_DEBUG_STREAM("FrontLight: "       << std::boolalpha << config.groups.capture.FrontLight);
-      ROS_DEBUG_STREAM("Gain: "             << config.groups.capture.Gain);
-      ROS_DEBUG_STREAM("GainBoost: "        << std::boolalpha << config.groups.capture.GainBoost);
-      ROS_DEBUG_STREAM("HardwareGamma: "    << std::boolalpha << config.groups.capture.HardwareGamma);
-      ROS_DEBUG_STREAM("Hdr: "              << std::boolalpha << config.groups.capture.Hdr);
-      ROS_DEBUG_STREAM("PixelClock: "       << config.groups.capture.PixelClock);
-      ROS_DEBUG_STREAM("Projector: "        << std::boolalpha << config.groups.capture.Projector);
-      ROS_DEBUG_STREAM("TargetBrightness: " << config.groups.capture.TargetBrightness);
+      ROS_DEBUG_STREAM("AutoBlackLevel: "   << std::boolalpha << config.AutoBlackLevel);
+      ROS_DEBUG_STREAM("AutoExposure: "     << std::boolalpha << config.AutoExposure);
+      ROS_DEBUG_STREAM("AutoGain: "         << std::boolalpha << config.AutoGain);
+      ROS_DEBUG_STREAM("Binning: "          << config.Binning);
+      ROS_DEBUG_STREAM("BlackLevelOffset: " << config.BlackLevelOffset);
+      ROS_DEBUG_STREAM("Exposure: "         << config.Exposure);
+      ROS_DEBUG_STREAM("FlexView: "         << std::boolalpha << config.FlexView);
+      ROS_DEBUG_STREAM("FlexViewImages: "   << config.FlexViewImages);
+      ROS_DEBUG_STREAM("FrontLight: "       << std::boolalpha << config.FrontLight);
+      ROS_DEBUG_STREAM("Gain: "             << config.Gain);
+      ROS_DEBUG_STREAM("GainBoost: "        << std::boolalpha << config.GainBoost);
+      ROS_DEBUG_STREAM("HardwareGamma: "    << std::boolalpha << config.HardwareGamma);
+      ROS_DEBUG_STREAM("Hdr: "              << std::boolalpha << config.Hdr);
+      ROS_DEBUG_STREAM("PixelClock: "       << config.PixelClock);
+      ROS_DEBUG_STREAM("Projector: "        << std::boolalpha << config.Projector);
+      ROS_DEBUG_STREAM("TargetBrightness: " << config.TargetBrightness);
       ROS_DEBUG_STREAM("TriggerMode: "      << trigger_mode);
-      ROS_DEBUG_STREAM("DisparityMapAOI: "  << std::boolalpha << config.groups.capture.DisparityMapAOI);
+      ROS_DEBUG_STREAM("DisparityMapAOI: "  << std::boolalpha << config.DisparityMapAOI);
       ROS_DEBUG("Stereo Matching Parameters");
-      ROS_DEBUG_STREAM("MinimumDisparity: "     << config.groups.stereo.MinimumDisparity);
-      ROS_DEBUG_STREAM("NumberOfDisparities: "  << config.groups.stereo.NumberOfDisparities);
+      ROS_DEBUG_STREAM("MinimumDisparity: "     << config.MinimumDisparity);
+      ROS_DEBUG_STREAM("NumberOfDisparities: "  << config.NumberOfDisparities);
       ROS_DEBUG_STREAM("OptimizationProfile: "  << profile);
-      ROS_DEBUG_STREAM("Scaling: "              << config.groups.stereo.Scaling);
+      ROS_DEBUG_STREAM("Scaling: "              << config.Scaling);
       ROS_DEBUG("Advanced Matching Parameters");
-      ROS_DEBUG_STREAM("DepthChangeCost: " << config.groups.stereo.DepthChangeCost);
-      ROS_DEBUG_STREAM("DepthStepCost: " << config.groups.stereo.DepthStepCost);
-      ROS_DEBUG_STREAM("ShadowingThreshold: " << config.groups.stereo.ShadowingThreshold);
+      ROS_DEBUG_STREAM("DepthChangeCost: " << config.DepthChangeCost);
+      ROS_DEBUG_STREAM("DepthStepCost: " << config.DepthStepCost);
+      ROS_DEBUG_STREAM("ShadowingThreshold: " << config.ShadowingThreshold);
       ROS_DEBUG("Postprocessing Parameters");
-      ROS_DEBUG_STREAM("UniquenessRatio: " << config.groups.postproc.UniquenessRatio);
-      ROS_DEBUG_STREAM("MedianFilterRadius: "<< config.groups.postproc.MedianFilterRadius);
-      ROS_DEBUG_STREAM("SpeckleComponentThreshold: "<< config.groups.postproc.SpeckleComponentThreshold);
-      ROS_DEBUG_STREAM("SpeckleRegionSize: "<< config.groups.postproc.SpeckleRegionSize);
-      ROS_DEBUG_STREAM("FillBorderSpread: "<< config.groups.postproc.FillBorderSpread);
-      ROS_DEBUG_STREAM("FillRegionSize: " << config.groups.postproc.FillRegionSize);
+      ROS_DEBUG_STREAM("UniquenessRatio: " << config.UniquenessRatio);
+      ROS_DEBUG_STREAM("MedianFilterRadius: "<< config.MedianFilterRadius);
+      ROS_DEBUG_STREAM("SpeckleComponentThreshold: "<< config.SpeckleComponentThreshold);
+      ROS_DEBUG_STREAM("SpeckleRegionSize: "<< config.SpeckleRegionSize);
+      ROS_DEBUG_STREAM("FillBorderSpread: "<< config.FillBorderSpread);
+      ROS_DEBUG_STREAM("FillRegionSize: " << config.FillRegionSize);
       ROS_DEBUG("Stream Parameters");
-      ROS_DEBUG_STREAM("Cloud: "   << std::boolalpha << config.groups.activate.Cloud);
-      ROS_DEBUG_STREAM("Images: "   << std::boolalpha << config.groups.activate.Images);
+      ROS_DEBUG_STREAM("Cloud: "   << std::boolalpha << config.Cloud);
+      ROS_DEBUG_STREAM("Images: "   << std::boolalpha << config.Images);
       ROS_DEBUG("---");
       // Capture parameters
-      ensenso_ptr_->setAutoBlackLevel(config.groups.capture.AutoBlackLevel);
-      ensenso_ptr_->setAutoExposure(config.groups.capture.AutoExposure);
-      ensenso_ptr_->setAutoGain(config.groups.capture.AutoGain);
-      ensenso_ptr_->setBlackLevelOffset(config.groups.capture.BlackLevelOffset);
-      ensenso_ptr_->setExposure(config.groups.capture.Exposure);
-      ensenso_ptr_->setFrontLight(config.groups.capture.FrontLight);
-      ensenso_ptr_->setGain(config.groups.capture.Gain);
-      ensenso_ptr_->setGainBoost(config.groups.capture.GainBoost);
-      ensenso_ptr_->setHardwareGamma(config.groups.capture.HardwareGamma);
-      ensenso_ptr_->setHdr(config.groups.capture.Hdr);
-      ensenso_ptr_->setPixelClock(config.groups.capture.PixelClock);
-      ensenso_ptr_->setProjector(config.groups.capture.Projector);
-      ensenso_ptr_->setTargetBrightness(config.groups.capture.TargetBrightness);
+      ensenso_ptr_->setAutoBlackLevel(config.AutoBlackLevel);
+      ensenso_ptr_->setAutoExposure(config.AutoExposure);
+      ensenso_ptr_->setAutoGain(config.AutoGain);
+      ensenso_ptr_->setBlackLevelOffset(config.BlackLevelOffset);
+      ensenso_ptr_->setExposure(config.Exposure);
+      ensenso_ptr_->setFrontLight(config.FrontLight);
+      ensenso_ptr_->setGain(config.Gain);
+      ensenso_ptr_->setGainBoost(config.GainBoost);
+      ensenso_ptr_->setHardwareGamma(config.HardwareGamma);
+      ensenso_ptr_->setHdr(config.Hdr);
+      ensenso_ptr_->setPixelClock(config.PixelClock);
+      ensenso_ptr_->setProjector(config.Projector);
+      ensenso_ptr_->setTargetBrightness(config.TargetBrightness);
       ensenso_ptr_->setTriggerMode(trigger_mode);
-      ensenso_ptr_->setUseDisparityMapAreaOfInterest(config.groups.capture.DisparityMapAOI);
+      ensenso_ptr_->setUseDisparityMapAreaOfInterest(config.DisparityMapAOI);
       // Flexview and binning only work in 'Software' trigger mode and with the projector on
-      if (trigger_mode.compare("Software") == 0 && config.groups.capture.Projector)
+      if (trigger_mode.compare("Software") == 0 && config.Projector)
       {
-        ensenso_ptr_->setBinning(config.groups.capture.Binning);
-        ensenso_ptr_->setFlexView(config.groups.capture.FlexView, config.groups.capture.FlexViewImages);
+        ensenso_ptr_->setBinning(config.Binning);
+        ensenso_ptr_->setFlexView(config.FlexView, config.FlexViewImages);
       }
       // Stereo parameters
-      ensenso_ptr_->setMinimumDisparity(config.groups.stereo.MinimumDisparity);
-      ensenso_ptr_->setNumberOfDisparities(config.groups.stereo.NumberOfDisparities);
+      ensenso_ptr_->setMinimumDisparity(config.MinimumDisparity);
+      ensenso_ptr_->setNumberOfDisparities(config.NumberOfDisparities);
       ensenso_ptr_->setOptimizationProfile(profile);
-      ensenso_ptr_->setScaling(config.groups.stereo.Scaling);
-      ensenso_ptr_->setDepthChangeCost(config.groups.stereo.DepthChangeCost);
-      ensenso_ptr_->setDepthStepCost(config.groups.stereo.DepthStepCost);
-      ensenso_ptr_->setShadowingThreshold(config.groups.stereo.ShadowingThreshold);
+      ensenso_ptr_->setScaling(config.Scaling);
+      ensenso_ptr_->setDepthChangeCost(config.DepthChangeCost);
+      ensenso_ptr_->setDepthStepCost(config.DepthStepCost);
+      ensenso_ptr_->setShadowingThreshold(config.ShadowingThreshold);
       //Postprocessing parameters
-      ensenso_ptr_->setUniquenessRatio(config.groups.postproc.UniquenessRatio);
-      ensenso_ptr_->setMedianFilterRadius(config.groups.postproc.MedianFilterRadius);
-      ensenso_ptr_->setSpeckleComponentThreshold(config.groups.postproc.SpeckleComponentThreshold);
-      ensenso_ptr_->setSpeckleRegionSize(config.groups.postproc.SpeckleRegionSize);
-      ensenso_ptr_->setFillBorderSpread(config.groups.postproc.FillBorderSpread);
-      ensenso_ptr_->setFillRegionSize(config.groups.postproc.FillRegionSize);
+      ensenso_ptr_->setUniquenessRatio(config.UniquenessRatio);
+      ensenso_ptr_->setMedianFilterRadius(config.MedianFilterRadius);
+      ensenso_ptr_->setSpeckleComponentThreshold(config.SpeckleComponentThreshold);
+      ensenso_ptr_->setSpeckleRegionSize(config.SpeckleRegionSize);
+      ensenso_ptr_->setFillBorderSpread(config.FillBorderSpread);
+      ensenso_ptr_->setFillRegionSize(config.FillRegionSize);
       // Streaming parameters
-      configureStreaming(config.groups.activate.Cloud, config.groups.activate.Images);
+      configureStreaming(config.Cloud, config.Images);
     }
     
     bool collectPatternCB(ensenso::CollectPattern::Request& req, ensenso::CollectPattern::Response &res)

--- a/src/ensenso_driver.cpp
+++ b/src/ensenso_driver.cpp
@@ -99,8 +99,7 @@ class EnsensoDriver
       dynamic_reconfigure::Server<ensenso::CameraParametersConfig>::CallbackType f;
       f = boost::bind(&EnsensoDriver::CameraParametersCallback, this, _1, _2);
       reconfigure_server_.setCallback(f);
-      // Start the camera. By default only stream images. You can use dynreconfigure to change the streaming
-      configureStreaming(true, false);
+      // Start the camera.
       ensenso_ptr_->start();
       // Advertise services
       calibrate_srv_ = nh_.advertiseService("calibrate_handeye", &EnsensoDriver::calibrateHandEyeCB, this);


### PR DESCRIPTION
This PR does the following things (see separate commit messages for details):

* The dynamic reconfigure parameters are now properly read from the parameter server, so we don't need the dynparam node any more.
* Some dynamic reconfigure params were missing from the launch file.
* Some dynamic reconfigure params didn't have default values.
* In uEye driver versions 4.80.7 and above, the default for BlackLevelOffset has changed. With the old value (1.0), this broke the AutoExposure feature.