### PR TITLE
Fix CMake dependencies of ensenso_driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,5 +86,5 @@ add_library(ensenso_grabber src/ensenso_grabber.cpp)
 target_link_libraries(ensenso_grabber ${ENSENSO_LIBRARIES} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
 
 add_executable(ensenso_driver src/ensenso_driver.cpp)
-add_dependencies(ensenso_driver ${catkin_EXPORTED_TARGETS})
+add_dependencies(ensenso_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(ensenso_driver ensenso_grabber ${PCL_LIBRARIES} ${catkin_LIBRARIES})


### PR DESCRIPTION
This makes sure that the messages are built before the driver.