### PR TITLE
Fix point cloud transformation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ensenso)
 
+# Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   camera_info_manager
   cmake_modules

--- a/include/ensenso/ensenso_grabber.h
+++ b/include/ensenso/ensenso_grabber.h
@@ -5,6 +5,7 @@
 #include <pcl/pcl_config.h>
 #include <pcl/common/io.h>
 #include <pcl/common/time.h>
+#include <pcl/common/transforms.h>
 #include <pcl/io/eigen.h>
 #include <pcl/io/boost.h>
 #include <pcl/io/grabber.h>
@@ -652,7 +653,7 @@ protected:
     /** @brief Retrieve RGB depth data from NxLib
     * @param[out] acquired point cloud and depth image
     */
-    void getDepthDataRGB(const pcl::PointCloud<pcl::PointXYZRGBA>::Ptr& cloud, const pcl::PCLGenImage<float>::Ptr& depthimage);
+    void getDepthDataRGB(pcl::PointCloud<pcl::PointXYZRGBA>::Ptr& cloud, const pcl::PCLGenImage<float>::Ptr& depthimage);
 
     /** @brief Retrieve depth data from NxLib
     * @param[out] acquired point cloud and depth image


### PR DESCRIPTION
Before this fix, the point cloud was improperly transformed into the rgb_optical_frame:

* `- tf_left_to_rgb_.tz` was missing, so the point cloud was not transformed in the Z direction at all
* the rotation was not taken into account

As a result, the coordinates of the points in the cloud were incorrect. This commit fixes that.